### PR TITLE
Add SSL_verify_mode to fix problem with disable verify hostname

### DIFF
--- a/check_nginx_status.pl
+++ b/check_nginx_status.pl
@@ -215,7 +215,9 @@ my $ua = LWP::UserAgent->new(
 );
 
 if ( $o_disable_sslverifyhostname ) {
-  $ua->ssl_opts( 'verify_hostname' => 0 );
+  $ua->ssl_opts( 'verify_hostname' => 0,
+  SSL_verify_mode => '0',
+  );
 }
 
 # we need to enforce the HTTP request is made on the Nagios Host IP and


### PR DESCRIPTION
This param fixes the error with disable_sslverifyhostname, which does not work, until the [option](https://metacpan.org/pod/IO::Socket::SSL) was set.